### PR TITLE
Add missing jobs key to eslint workflow

### DIFF
--- a/.github/workflows/eslint.yaml
+++ b/.github/workflows/eslint.yaml
@@ -9,6 +9,7 @@ on:
       - "package*.json"
       - ".eslintrc.js"
 
+jobs:
   npm-lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
- Add missing `jobs` to `eslint.yaml` 